### PR TITLE
修复悬浮窗拖动后位置无法保存的 bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -5373,6 +5373,13 @@ import { messageFormatting as coreMessageFormatting } from '../../../../script.j
     // 恢复CSS过渡
     root.style.transition = '';
 
+    // 延迟修正：布局稳定后重新定位，消除初始化时瞬时尺寸导致的偏差
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        applyRootPositionFromSettings(root);
+      });
+    });
+
     attachDrag(root);
     bindButtons(root);
     bindFavoritesPanel(root);

--- a/index.js
+++ b/index.js
@@ -4548,8 +4548,12 @@ import { messageFormatting as coreMessageFormatting } from '../../../../script.j
 
     settings.x = Math.round(clampedLeft);
     settings.y = Math.round(clampedTop);
-    settings.rx = maxLeft > 0 ? clamp(clampedLeft / maxLeft, 0, 1) : 0;
-    settings.ry = maxTop > 0 ? clamp(clampedTop / maxTop, 0, 1) : 0;
+    if (maxLeft > 0) {
+      settings.rx = clamp(clampedLeft / maxLeft, 0, 1);
+    }
+    if (maxTop > 0) {
+      settings.ry = clamp(clampedTop / maxTop, 0, 1);
+    }
     saveSettings();
     applyFavoritePanelPosition(root, { force: true });
   }
@@ -4563,9 +4567,15 @@ import { messageFormatting as coreMessageFormatting } from '../../../../script.j
   function applyRootPositionFromSettings(root) {
     const { maxLeft, maxTop } = getRootMaxOffsets(root);
 
-    // 优先使用相对位置（rx/ry）
+    // 优先使用相对位置（rx/ry）：直接设置DOM位置，不触发保存
     if (typeof settings.rx === 'number' && typeof settings.ry === 'number') {
-      persistRootPosition(root, settings.rx * maxLeft, settings.ry * maxTop);
+      const left = clamp(settings.rx * maxLeft, 0, maxLeft);
+      const top = clamp(settings.ry * maxTop, 0, maxTop);
+      root.style.left = `${left}px`;
+      root.style.top = `${top}px`;
+      settings.x = Math.round(left);
+      settings.y = Math.round(top);
+      applyFavoritePanelPosition(root, { force: true });
       return;
     }
 
@@ -4593,21 +4603,32 @@ import { messageFormatting as coreMessageFormatting } from '../../../../script.j
       resizeRaf = requestAnimationFrame(() => {
         resizeRaf = null;
 
-        // 有相对位置时：按相对位置重新计算，保证窗口变化后仍保持相对位置
+        // 有相对位置时：直接设置DOM位置，不触发保存
         if (typeof settings.rx === 'number' && typeof settings.ry === 'number') {
           const { maxLeft, maxTop } = getRootMaxOffsets(root);
-          persistRootPosition(root, settings.rx * maxLeft, settings.ry * maxTop);
+          const left = clamp(settings.rx * maxLeft, 0, maxLeft);
+          const top = clamp(settings.ry * maxTop, 0, maxTop);
+          root.style.left = `${left}px`;
+          root.style.top = `${top}px`;
+          settings.x = Math.round(left);
+          settings.y = Math.round(top);
+          applyFavoritePanelPosition(root, { force: true });
           return;
         }
 
-        // 兜底：仅做 clamp
+        // 兜底：仅做 clamp（旧版像素坐标，需转换保存）
         clampRootIntoViewport(root);
       });
     } catch {
       // 极少数环境不支持 rAF：直接处理
       if (typeof settings.rx === 'number' && typeof settings.ry === 'number') {
         const { maxLeft, maxTop } = getRootMaxOffsets(root);
-        persistRootPosition(root, settings.rx * maxLeft, settings.ry * maxTop);
+        const left = clamp(settings.rx * maxLeft, 0, maxLeft);
+        const top = clamp(settings.ry * maxTop, 0, maxTop);
+        root.style.left = `${left}px`;
+        root.style.top = `${top}px`;
+        settings.x = Math.round(left);
+        settings.y = Math.round(top);
         return;
       }
       clampRootIntoViewport(root);
@@ -5329,6 +5350,9 @@ import { messageFormatting as coreMessageFormatting } from '../../../../script.j
 
     document.body.appendChild(root);
 
+    // 暂时禁用CSS过渡，确保初始位置计算不受过渡动画影响
+    root.style.transition = 'none';
+
     // 初始布局
     root.style.setProperty('--stcj-scale', String(normalizeRootScale(settings.scale)));
     root.classList.toggle('stcj-horizontal', settings.orientation === 'horizontal');
@@ -5345,6 +5369,9 @@ import { messageFormatting as coreMessageFormatting } from '../../../../script.j
 
     // 初始位置
     applyRootPositionFromSettings(root);
+
+    // 恢复CSS过渡
+    root.style.transition = '';
 
     attachDrag(root);
     bindButtons(root);


### PR DESCRIPTION
## 问题描述

拖动悬浮窗到新位置后，刷新页面位置会丢失，回到默认位置或屏幕顶部。

## 根因分析

发现三个独立问题，叠加起来导致了这个 bug：

### 1. 恢复位置时回写覆盖了正确的保存值

`applyRootPositionFromSettings()` 和 `scheduleRepositionOnResize()` 在恢复已保存的相对位置时，内部调用 `persistRootPosition()` 会反算出当前的 `rx/ry` 然后立即 `saveSettings()`。如果反算时的 DOM 尺寸和拖拽保存时略有差异，就会算出错误的 `rx/ry` 覆盖掉 localStorage 中正确的值。

**修复**：恢复位置时只设置 DOM 的 `left/top`，不调用 `persistRootPosition`（不触发保存）。`rx/ry` 保持不变。

### 2. `maxTop`/`maxLeft` 为 0 时 `rx/ry` 被错误清零

`persistRootPosition()` 中当 `maxTop = 0`（悬浮窗高度 > 视口高度，例如小屏+大缩放比例）时，`ry` 被直接赋值为 `0` 并保存。一旦保存了 `ry=0`，后续每次刷新都会因为 `top = 0 * maxTop = 0` 而把窗口定位到顶部，形成死循环。

**修复**：`maxLeft`/`maxTop` 为 0 时，保留原有的 `rx/ry` 值不覆盖。

### 3. 初始化时 CSS 布局未稳定导致位置计算偏差

`buildUI()` 中 `applyRootPositionFromSettings()` 调用时，`getBoundingClientRect()` 拿到的 root 尺寸可能是中间态（约 554px 高），而布局完全稳定后 root 实际只有约 249px。`maxTop` 从 153 变成 458，导致用 `ry=0.5` 计算出的 `top` 从 77px（错误）变成 230px（正确）。

**修复**：
- 初始化时临时禁用 CSS `transition`（`root.style.transition = 'none'`），避免 scale 过渡动画影响尺寸计算
- 通过双 `requestAnimationFrame` 在布局完全稳定后重新执行一次定位

## 改动文件

- `index.js`：修改 `persistRootPosition`、`applyRootPositionFromSettings`、`scheduleRepositionOnResize`、`buildUI` 四个函数

🤖 Generated with [Claude Code](https://claude.com/claude-code)
